### PR TITLE
Update extension.yaml to include link to API key request form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.7
+
+- Update API key param description to link to the request form
+
 ## Version 0.1.6
 
 - Update extension display name and description

--- a/extension.yaml
+++ b/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-perspective-toxicity
-version: 0.1.6
+version: 0.1.7
 specVersion: v1beta
 
 displayName: Analyze Comment Toxicity with Perspective API

--- a/extension.yaml
+++ b/extension.yaml
@@ -111,7 +111,8 @@ params:
   - param: PERSPECTIVE_API_KEY
     label: Perspective API Key
     description: >
-      What is the API key that will be used to call Perspective API?
+      What is the API key that will be used to call Perspective API? (You can request one 
+      [here](https://docs.google.com/forms/d/e/1FAIpQLSdhBBnVVVbXSElby-jhNnEj-Zwpt5toQSCFsJerGfpXW66CuQ/viewform)
     required: true
 
   - param: ATTRIBUTES


### PR DESCRIPTION
I was going through a demo experience and felt a link to the form would be helpful. 
Using this link https://docs.google.com/forms/d/e/1FAIpQLSdhBBnVVVbXSElby-jhNnEj-Zwpt5toQSCFsJerGfpXW66CuQ/viewform